### PR TITLE
Fixes #36

### DIFF
--- a/field_collection.module
+++ b/field_collection.module
@@ -1510,7 +1510,7 @@ function field_collection_field_attach_form($entity_type, $entity, &$form, &$for
     foreach (field_info_instances($entity_type, $form['#bundle']) as $field_name => $instance) {
       $field = field_info_field($field_name);
       if (isset($field['translatable'])) {
-        $form[$field_name]['#multilingual'] = (boolean) $field['translatable'];
+        $form[$field_name]['#multilingual'] = (bool) $field['translatable'];
       }
     }
   }


### PR DESCRIPTION
PHP 8.5 compatibility fix for deprecation of non-canonical casting syntax.

Functional tests won't run, see #29 for details.