### PR TITLE
Fixes #42

### DIFF
--- a/field_collection.module
+++ b/field_collection.module
@@ -504,8 +504,10 @@ function field_collection_field_insert($host_entity_type, $host_entity, $field, 
         'revision_id' => $entity->revision_id,
       );
 
-      module_load_include('inc', 'path');
-      path_save_automatic_entity_alias($entity);
+      if (module_exists('path')) {
+        module_load_include('inc', 'path');
+        path_save_automatic_entity_alias($entity);
+      }
 
       // This is necessary to get the $host_entity to display the new field
       // collection item.
@@ -601,8 +603,10 @@ function field_collection_field_update($host_entity_type, $host_entity, $field, 
           'revision_id' => $entity->revision_id,
         );
 
-        module_load_include('inc', 'path');
-        path_save_automatic_entity_alias($entity);
+        if (module_exists('path')) {
+          module_load_include('inc', 'path');
+          path_save_automatic_entity_alias($entity);
+        }
 
         // This is necessary to get the $host_entity to display the new field
         // collection item.


### PR DESCRIPTION
The Drupal version of this module wraps its (optional) pathauto logic in a module_exists() check that got left behind in the migration to Backdrop.

Restoring this here so that we don't need to require the path module to be enabled for content to save successfully.